### PR TITLE
ci: align workflows with webfiori/http

### DIFF
--- a/.github/workflows/php81.yaml
+++ b/.github/workflows/php81.yaml
@@ -5,23 +5,24 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run Tests
-    uses: WebFiori/workflows/.github/workflows/test-php.yaml@main
+    uses: WebFiori/workflows/.github/workflows/test-php.yaml@v1.2.5
     with:
       php-version: '8.1'
-    secrets: inherit
+      phpunit-config: 'tests/phpunit.xml'
 
   code-coverage:
     name: Coverage
     needs: test
-    uses: WebFiori/workflows/.github/workflows/coverage-codecov.yaml@main
+    uses: WebFiori/workflows/.github/workflows/coverage-codecov.yaml@v1.2.5
     with:
       php-version: '8.1'
       coverage-file: 'php-8.1-coverage.xml'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    
-        
-          

--- a/.github/workflows/php82.yaml
+++ b/.github/workflows/php82.yaml
@@ -5,24 +5,24 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run Tests
-    uses: WebFiori/workflows/.github/workflows/test-php.yaml@main
+    uses: WebFiori/workflows/.github/workflows/test-php.yaml@v1.2.5
     with:
       php-version: '8.2'
-      phpunit-config: "tests/phpunit10.xml"
-    secrets: inherit
+      phpunit-config: 'tests/phpunit.xml'
 
   code-coverage:
     name: Coverage
     needs: test
-    uses: WebFiori/workflows/.github/workflows/coverage-codecov.yaml@main
+    uses: WebFiori/workflows/.github/workflows/coverage-codecov.yaml@v1.2.5
     with:
       php-version: '8.2'
       coverage-file: 'php-8.2-coverage.xml'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    
-        
-          

--- a/.github/workflows/php83.yaml
+++ b/.github/workflows/php83.yaml
@@ -5,40 +5,24 @@ on:
     branches: [ main, dev ]
   pull_request:
     branches: [ main, dev ]
-env:
-  OPERATING_SYS: ubuntu-latest
-  PHP_VERSION: 8.3
-jobs:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     name: Run Tests
-    uses: WebFiori/workflows/.github/workflows/test-php.yaml@main
+    uses: WebFiori/workflows/.github/workflows/test-php.yaml@v1.2.5
     with:
       php-version: '8.3'
-      phpunit-config: 'tests/phpunit10.xml'
-    secrets: inherit
-            
+      phpunit-config: 'tests/phpunit.xml'
 
   code-coverage:
     name: Coverage
     needs: test
-    uses: WebFiori/workflows/.github/workflows/coverage-codecov.yaml@main
+    uses: WebFiori/workflows/.github/workflows/coverage-codecov.yaml@v1.2.5
     with:
       php-version: '8.3'
       coverage-file: 'php-8.3-coverage.xml'
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}  
-
-  code-quality:
-    name: Code Quality
-    needs: test
-    uses: WebFiori/workflows/.github/workflows/quality-sonarcloud.yaml@main
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          
-  release-prod:
-    name: Prepare Production Release Branch / Publish Release
-    needs: [code-coverage, code-quality]
-    uses: WebFiori/workflows/.github/workflows/release-php.yaml@main
-    with:
-      branch: 'main'
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/php84.yaml
+++ b/.github/workflows/php84.yaml
@@ -5,24 +5,24 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run Tests
-    uses: WebFiori/workflows/.github/workflows/test-php.yaml@main
+    uses: WebFiori/workflows/.github/workflows/test-php.yaml@v1.2.5
     with:
       php-version: '8.4'
-      phpunit-config: "tests/phpunit10.xml"
-    secrets: inherit
+      phpunit-config: 'tests/phpunit.xml'
 
   code-coverage:
     name: Coverage
     needs: test
-    uses: WebFiori/workflows/.github/workflows/coverage-codecov.yaml@main
+    uses: WebFiori/workflows/.github/workflows/coverage-codecov.yaml@v1.2.5
     with:
       php-version: '8.4'
       coverage-file: 'php-8.4-coverage.xml'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    
-        
-          

--- a/.github/workflows/php85.yaml
+++ b/.github/workflows/php85.yaml
@@ -1,0 +1,43 @@
+name: Build PHP 8.5
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run Tests
+    uses: WebFiori/workflows/.github/workflows/test-php.yaml@v1.2.5
+    with:
+      php-version: '8.5'
+      phpunit-config: 'tests/phpunit.xml'
+
+  code-coverage:
+    name: Coverage
+    needs: test
+    uses: WebFiori/workflows/.github/workflows/coverage-codecov.yaml@v1.2.5
+    with:
+      php-version: '8.5'
+      coverage-file: 'php-8.5-coverage.xml'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  code-quality:
+    name: Code Quality
+    needs: test
+    uses: WebFiori/workflows/.github/workflows/quality-sonarcloud.yaml@v1.2.5
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  release-prod:
+    name: Prepare Production Release Branch / Publish Release
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: [code-coverage, code-quality]
+    uses: WebFiori/workflows/.github/workflows/release-php.yaml@v1.2.5
+    with:
+      branch: 'main'


### PR DESCRIPTION
# Summary
Aligns CI workflows in this repo with the patterns used in webfiori/http.

## Motivation
Workflows were outdated — referencing `@main` instead of pinned versions, missing concurrency controls, lacking PHP 8.5 coverage, and using inconsistent configurations.

## Changes
- Pin reusable workflows to `@v1.2.5` instead of `@main`
- Add concurrency groups with `cancel-in-progress: true`
- Use consistent `phpunit-config` (`tests/phpunit.xml`) across all versions
- Remove `secrets: inherit` in favor of explicit secret passing
- Add PHP 8.5 workflow with code quality and release jobs
- Add conditional release gate (only on push to main)
- Remove unused env variables from php83 workflow

## UI Changes
None.

## How to Test / Verify
Verify workflows execute correctly on push/PR to main. Check that all PHP versions (8.1–8.5) run tests and report coverage.

## Breaking Changes and Migration Steps
None.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Not Applicable