### PR TITLE
feat: Add TransportInterface and SmtpTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Comprehensive examples are available in the [`examples/`](examples/) directory:
 - **[Sending Modes](examples/sending-modes/)** - Test, development, and production configurations
 - **[SMTP Logging](examples/accessing-log/)** - Debugging and monitoring
 - **[Callbacks](examples/callbacks/)** - Before/after send custom logic
+- **[Custom Transports](examples/transports/)** - Connection reuse and pluggable transports
 
 ## Testing
 

--- a/WebFiori/Mail/Email.php
+++ b/WebFiori/Mail/Email.php
@@ -355,6 +355,14 @@ class Email {
         return $this->getReceiversStrHelper('bcc');
     }
     /**
+     * Returns the boundary string used to separate email message parts.
+     * 
+     * @return string The boundary string.
+     */
+    public function getBoundary() : string {
+        return $this->boundry;
+    }
+    /**
      * Returns an associative array that contains the names and the addresses 
      * of people who will receive a carbon copy of the message.
      * 
@@ -652,13 +660,15 @@ class Email {
     /**
      * Sends the message.
      * 
-     * @param SMTPServer|null $server An optional external SMTPServer instance to use
-     * for sending. This allows reusing an already-authenticated connection. If null,
-     * a new connection will be created from the SMTPAccount.
+     * @param TransportInterface|SMTPServer|null $transport An optional transport
+     * to use for delivery. Can be:
+     * - A TransportInterface implementation (e.g. SmtpTransport)
+     * - An SMTPServer instance for backward compatibility (reuses connection)
+     * - null to use the default SMTP transport from the configured account
      * 
      * @throws SMTPException
      */
-    public function send(SMTPServer|null $server = null) {
+    public function send(TransportInterface|SMTPServer|null $transport = null) {
         if ($this->isSent()) {
             throw new SMTPException('Message was already sent.');
         }
@@ -703,57 +713,26 @@ class Email {
                     $this->addTo($trimmed);
                 }
             }
-        } 
+        }
 
+        if ($transport instanceof TransportInterface) {
+            $transport->send($this);
+            $this->invokeAfterSend();
+
+            return;
+        }
+
+        // Backward compatibility: SMTPServer instance or null
         $acc = $this->getSMTPAccount();
 
-        if ($server !== null) {
-            $this->smtpServer = $server;
-        }
-        $smtpServer = $this->getSMTPServer();
-
-        if ($this->rcptCount() == 0) {
-            throw new SMTPException('No message recipients.');
+        if ($transport instanceof SMTPServer) {
+            $this->smtpServer = $transport;
         }
 
-        $isExternalServer = $server !== null && $smtpServer->isConnected();
-
-        if ($isExternalServer || $this->authenticate($smtpServer, $acc)) {
-            $smtpServer->sendCommand('MAIL FROM: <'.$acc->getAddress().'>');
-
-            $this->receiversCommandHelper('to');
-            $this->receiversCommandHelper('cc');
-            $this->receiversCommandHelper('bcc');
-            $smtpServer->sendCommand('DATA');
-            $importanceHeaderVal = $this->priorityCommandHelper();
-
-            $smtpServer->sendCommand('Importance: '.$importanceHeaderVal);
-            $smtpServer->sendCommand('From: =?UTF-8?B?'.base64_encode($acc->getSenderName()).'?= <'.$acc->getAddress().'>');
-            $smtpServer->sendCommand('To: '.$this->getReceiversStrHelper('to'), false);
-            $smtpServer->sendCommand('CC: '.$this->getReceiversStrHelper('cc'), false);
-            $smtpServer->sendCommand('BCC: '.$this->getReceiversStrHelper('bcc'), false);
-            $smtpServer->sendCommand('Date:'.date('r (T)'));
-            $smtpServer->sendCommand('Subject:'.'=?UTF-8?B?'.base64_encode($this->getSubject()).'?=');
-            $smtpServer->sendCommand('MIME-Version: 1.0');
-            $smtpServer->sendCommand('Content-Type: multipart/mixed; boundary="'.$this->boundry.'"'.SMTPServer::NL);
-            $smtpServer->sendCommand('--'.$this->boundry);
-            $smtpServer->sendCommand('Content-Type: multipart/alternative; boundary="'.$this->boundry.'-alt"'.SMTPServer::NL);
-            $smtpServer->sendCommand('--'.$this->boundry.'-alt');
-            $smtpServer->sendCommand('Content-Type: text/plain; charset="UTF-8"');
-            $smtpServer->sendCommand('Content-Transfer-Encoding: quoted-printable'.SMTPServer::NL);
-            $smtpServer->sendCommand($this->getPlainTextBody());
-            $smtpServer->sendCommand('--'.$this->boundry.'-alt');
-            $smtpServer->sendCommand('Content-Type: text/html; charset="UTF-8"');
-            $smtpServer->sendCommand('Content-Transfer-Encoding: quoted-printable'.SMTPServer::NL);
-            $smtpServer->sendCommand($this->trimControlChars($this->getDocument()->toHTML()));
-            $smtpServer->sendCommand('--'.$this->boundry.'-alt--');
-            $this->appendAttachments();
-            $smtpServer->sendCommand(SMTPServer::NL.'.');
-            $smtpServer->sendCommand('QUIT');
-            $this->invokeAfterSend();
-        } else {
-            throw new SMTPException('Unable to login to SMTP server: '.$smtpServer->getLastResponse(), $smtpServer->getLastResponseCode(), $smtpServer->getLog());
-        }
+        $smtpTransport = new SmtpTransport($acc, $this->getSMTPServer());
+        $smtpTransport->send($this);
+        $this->smtpServer = $smtpTransport->getServer();
+        $this->invokeAfterSend();
     }
     /**
      * Sets the display language of the email.

--- a/WebFiori/Mail/SmtpTransport.php
+++ b/WebFiori/Mail/SmtpTransport.php
@@ -1,0 +1,208 @@
+<?php
+namespace WebFiori\Mail;
+
+use WebFiori\Mail\Exceptions\SMTPException;
+
+/**
+ * SMTP transport implementation that delivers emails via SMTP protocol.
+ *
+ * This is the default transport used by the library. It extracts the SMTP
+ * delivery logic that was previously embedded in Email::send().
+ *
+ * @author Ibrahim
+ */
+class SmtpTransport implements TransportInterface {
+    private SMTPAccount $account;
+    private ?SMTPServer $server;
+
+    /**
+     * Creates a new SMTP transport instance.
+     *
+     * @param SMTPAccount $account The SMTP account to use for authentication.
+     *
+     * @param SMTPServer|null $server An optional pre-connected server instance.
+     * If null, a new connection will be established using the account details.
+     */
+    public function __construct(SMTPAccount $account, ?SMTPServer $server = null) {
+        $this->account = $account;
+        $this->server = $server;
+    }
+
+    /**
+     * Returns the SMTP account used by this transport.
+     *
+     * @return SMTPAccount
+     */
+    public function getAccount(): SMTPAccount {
+        return $this->account;
+    }
+
+    public function getName(): string {
+        return 'smtp';
+    }
+
+    /**
+     * Returns the SMTP server instance used by this transport.
+     *
+     * @return SMTPServer
+     */
+    public function getServer(): SMTPServer {
+        if ($this->server === null) {
+            $this->server = new SMTPServer(
+                $this->account->getServerAddress(),
+                $this->account->getPort()
+            );
+        }
+
+        return $this->server;
+    }
+
+    /**
+     * Send an email message via SMTP.
+     *
+     * @param Email $message The email to send.
+     *
+     * @throws SMTPException If authentication or sending fails.
+     */
+    public function send(Email $message): void {
+        $acc = $this->account;
+        $server = $this->getServer();
+
+        if ($message->rcptCount() == 0) {
+            throw new SMTPException('No message recipients.');
+        }
+
+        $isExternal = $this->server !== null && $server->isConnected();
+
+        if ($isExternal || $this->authenticate($server, $acc)) {
+            $server->sendCommand('MAIL FROM: <'.$acc->getAddress().'>');
+
+            $this->sendRecipients($message, $server);
+            $server->sendCommand('DATA');
+            $this->sendHeaders($message, $server, $acc);
+            $this->sendBody($message, $server);
+            $this->sendAttachments($message, $server);
+            $server->sendCommand(SMTPServer::NL.'.');
+            $server->sendCommand('QUIT');
+        } else {
+            throw new SMTPException(
+                'Unable to login to SMTP server: '.$server->getLastResponse(),
+                $server->getLastResponseCode(),
+                $server->getLog()
+            );
+        }
+    }
+
+    private function authenticate(SMTPServer $server, SMTPAccount $account): bool {
+        $accessToken = $account->getAccessToken();
+
+        if ($accessToken !== null) {
+            return $server->authOAuth($account->getUsername(), $accessToken);
+        }
+
+        return $server->authLogin($account->getUsername(), $account->getPassword());
+    }
+
+    private function formatRecipients(array $recipients): string {
+        $arr = [];
+
+        foreach ($recipients as $address => $name) {
+            $arr[] = '=?UTF-8?B?'.base64_encode($name).'?='.' <'.$address.'>';
+        }
+
+        return implode(',', $arr);
+    }
+
+    private function getPlainTextBody(Email $message): string {
+        $html = $message->getDocument()->getBody()->toHTML();
+        $text = strip_tags($html);
+        $text = html_entity_decode($text, ENT_QUOTES, 'UTF-8');
+        $text = preg_replace("/[ \t]+/", ' ', $text);
+        $text = preg_replace("/\n\s*\n+/", "\n\n", $text);
+
+        return trim($text);
+    }
+
+    private function sendAttachments(Email $message, SMTPServer $server): void {
+        $files = $message->getAttachments();
+
+        if (count($files) != 0) {
+            $boundary = $message->getBoundary();
+
+            foreach ($files as $fileObj) {
+                $fileObj->read();
+                $contentChunk = chunk_split($fileObj->getRawData(true));
+                $server->sendCommand('--'.$boundary);
+                $server->sendCommand('Content-Type: '.$fileObj->getMIME().'; name="'.$fileObj->getName().'"');
+                $server->sendCommand('Content-Transfer-Encoding: base64');
+                $server->sendCommand('Content-Disposition: attachment; filename="'.$fileObj->getName().'"'.SMTPServer::NL);
+                $server->sendCommand($contentChunk);
+            }
+            $server->sendCommand('--'.$boundary.'--'.SMTPServer::NL);
+        }
+    }
+
+    private function sendBody(Email $message, SMTPServer $server): void {
+        $boundary = $message->getBoundary();
+        $server->sendCommand('Content-Type: multipart/mixed; boundary="'.$boundary.'"'.SMTPServer::NL);
+        $server->sendCommand('--'.$boundary);
+        $server->sendCommand('Content-Type: multipart/alternative; boundary="'.$boundary.'-alt"'.SMTPServer::NL);
+        $server->sendCommand('--'.$boundary.'-alt');
+        $server->sendCommand('Content-Type: text/plain; charset="UTF-8"');
+        $server->sendCommand('Content-Transfer-Encoding: quoted-printable'.SMTPServer::NL);
+        $server->sendCommand($this->getPlainTextBody($message));
+        $server->sendCommand('--'.$boundary.'-alt');
+        $server->sendCommand('Content-Type: text/html; charset="UTF-8"');
+        $server->sendCommand('Content-Transfer-Encoding: quoted-printable'.SMTPServer::NL);
+        $server->sendCommand($this->trimControlChars($message->getDocument()->toHTML()));
+        $server->sendCommand('--'.$boundary.'-alt--');
+    }
+
+    private function sendHeaders(Email $message, SMTPServer $server, SMTPAccount $acc): void {
+        $priorityAsInt = $message->getPriority();
+        $priorities = Email::PRIORITIES;
+        $priorityHeaderVal = $priorities[$priorityAsInt];
+
+        if ($priorityAsInt == -1) {
+            $importanceHeaderVal = 'low';
+        } else if ($priorityAsInt == 1) {
+            $importanceHeaderVal = 'High';
+        } else {
+            $importanceHeaderVal = 'normal';
+        }
+
+        $server->sendCommand('Priority: '.$priorityHeaderVal);
+        $server->sendCommand('Importance: '.$importanceHeaderVal);
+        $server->sendCommand('From: =?UTF-8?B?'.base64_encode($acc->getSenderName()).'?= <'.$acc->getAddress().'>');
+        $server->sendCommand('To: '.$this->formatRecipients($message->getTo()));
+        $server->sendCommand('CC: '.$this->formatRecipients($message->getCC()));
+        $server->sendCommand('BCC: '.$this->formatRecipients($message->getBCC()));
+        $server->sendCommand('Date:'.date('r (T)'));
+        $server->sendCommand('Subject:'.'=?UTF-8?B?'.base64_encode($message->getSubject()).'?=');
+        $server->sendCommand('MIME-Version: 1.0');
+    }
+
+    private function sendRecipients(Email $message, SMTPServer $server): void {
+        $this->sendRecipientsOfType($message->getTo(), $server);
+        $this->sendRecipientsOfType($message->getCC(), $server);
+        $this->sendRecipientsOfType($message->getBCC(), $server);
+    }
+
+    private function sendRecipientsOfType(array $recipients, SMTPServer $server): void {
+        foreach ($recipients as $address => $name) {
+            $server->sendCommand('RCPT TO: <'.$address.'>');
+
+            if ($server->getLastResponseCode() == 451) {
+                $server->reset();
+                sleep(1);
+                $server->sendCommand('RCPT TO: <'.$address.'>');
+            }
+        }
+    }
+
+    private function trimControlChars(string $str): string {
+        $trimmed = trim($str, "\x00..\x20");
+
+        return preg_replace("/(\s*[\r\n]+\s*|\s+)/", ' ', $trimmed);
+    }
+}

--- a/WebFiori/Mail/SmtpTransport.php
+++ b/WebFiori/Mail/SmtpTransport.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026-present WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
 namespace WebFiori\Mail;
 
 use WebFiori\Mail\Exceptions\SMTPException;

--- a/WebFiori/Mail/TransportInterface.php
+++ b/WebFiori/Mail/TransportInterface.php
@@ -1,0 +1,27 @@
+<?php
+namespace WebFiori\Mail;
+
+/**
+ * Interface that defines a contract for email delivery transports.
+ *
+ * Implementations can provide different delivery mechanisms such as
+ * SMTP, API-based providers (SES, SendGrid), or test/null transports.
+ *
+ * @author Ibrahim
+ */
+interface TransportInterface {
+    /**
+     * Returns the name of the transport.
+     *
+     * @return string A string that identifies this transport (e.g. 'smtp', 'ses').
+     */
+    public function getName(): string;
+    /**
+     * Send an email message.
+     *
+     * @param Email $message The email to send.
+     *
+     * @throws Exceptions\SMTPException If sending fails.
+     */
+    public function send(Email $message): void;
+}

--- a/WebFiori/Mail/TransportInterface.php
+++ b/WebFiori/Mail/TransportInterface.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026-present WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
 namespace WebFiori\Mail;
 
 /**

--- a/examples/accessing-log/log-analysis.php
+++ b/examples/accessing-log/log-analysis.php
@@ -2,96 +2,104 @@
 
 require '../../vendor/autoload.php';
 
+use WebFiori\Mail\AccountOption;
 use WebFiori\Mail\Email;
 use WebFiori\Mail\SMTPAccount;
-use WebFiori\Mail\AccountOption;
 
 /**
  * Advanced SMTP log analysis and debugging utility
  */
-class SMTPLogAnalyzer
-{
+class SMTPLogAnalyzer {
     private $logs = [];
-    
-    public function __construct(array $logs)
-    {
+
+    public function __construct(array $logs) {
         $this->logs = $logs;
     }
-    
-    public function getConnectionPhase(): array
-    {
-        $connectionLogs = [];
-        foreach ($this->logs as $log) {
-            $code = $log['response-code'] ?? '';
-            if (in_array($code, ['220', '221'])) {
-                $connectionLogs[] = $log;
-            }
-        }
-        return $connectionLogs;
-    }
-    
-    public function getAuthenticationPhase(): array
-    {
+
+    public function getAuthenticationPhase(): array {
         $authLogs = [];
+
         foreach ($this->logs as $log) {
             $code = $log['response-code'] ?? '';
+
             if (in_array($code, ['334', '235', '535'])) {
                 $authLogs[] = $log;
             }
         }
+
         return $authLogs;
     }
-    
-    public function getMailTransactionPhase(): array
-    {
-        $mailLogs = [];
+
+    public function getConnectionPhase(): array {
+        $connectionLogs = [];
+
         foreach ($this->logs as $log) {
             $code = $log['response-code'] ?? '';
-            if (in_array($code, ['250', '354', '550', '551', '552', '553', '554'])) {
-                $mailLogs[] = $log;
+
+            if (in_array($code, ['220', '221'])) {
+                $connectionLogs[] = $log;
             }
         }
-        return $mailLogs;
+
+        return $connectionLogs;
     }
-    
-    public function hasErrors(): bool
-    {
-        foreach ($this->logs as $log) {
-            $code = $log['response-code'] ?? '';
-            if (strlen($code) > 0 && in_array($code[0], ['4', '5'])) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    public function getErrors(): array
-    {
+
+    public function getErrors(): array {
         $errors = [];
+
         foreach ($this->logs as $log) {
             $code = $log['response-code'] ?? '';
+
             if (strlen($code) > 0 && in_array($code[0], ['4', '5'])) {
                 $errors[] = $log;
             }
         }
+
         return $errors;
     }
-    
-    public function getSuccessRate(): float
-    {
+
+    public function getMailTransactionPhase(): array {
+        $mailLogs = [];
+
+        foreach ($this->logs as $log) {
+            $code = $log['response-code'] ?? '';
+
+            if (in_array($code, ['250', '354', '550', '551', '552', '553', '554'])) {
+                $mailLogs[] = $log;
+            }
+        }
+
+        return $mailLogs;
+    }
+
+    public function getSuccessRate(): float {
         if (empty($this->logs)) {
             return 0.0;
         }
-        
+
         $successCount = 0;
+
         foreach ($this->logs as $log) {
             $code = $log['response-code'] ?? '';
+
             if (in_array($code, ['220', '221', '250', '235', '354'])) {
                 $successCount++;
             }
         }
-        
+
         return ($successCount / count($this->logs)) * 100;
+    }
+
+    public function hasErrors(): bool {
+        foreach ($this->logs as $log) {
+            $code = $log['response-code'] ?? '';
+
+            if (strlen($code) > 0 && in_array($code[0], ['4', '5'])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }
 
@@ -131,7 +139,7 @@ $email3->subject('Log Analysis Test #3')
 $emails = [$email1, $email2, $email3];
 
 echo "SMTP LOG ANALYSIS UTILITY\n";
-echo str_repeat("=", 60) . "\n\n";
+echo str_repeat("=", 60)."\n\n";
 
 $allLogs = [];
 $emailResults = [];
@@ -139,78 +147,80 @@ $emailResults = [];
 // Send emails and collect logs
 foreach ($emails as $index => $email) {
     $emailNum = $index + 1;
-    echo "Processing Email #$emailNum: " . $email->getSubject() . "\n";
-    echo str_repeat("-", 40) . "\n";
-    
+    echo "Processing Email #$emailNum: ".$email->getSubject()."\n";
+    echo str_repeat("-", 40)."\n";
+
     try {
         $email->send();
         $status = "✅ SUCCESS";
     } catch (Exception $e) {
-        $status = "❌ FAILED: " . $e->getMessage();
+        $status = "❌ FAILED: ".$e->getMessage();
     }
-    
+
     $logs = $email->getLog();
     $analyzer = new SMTPLogAnalyzer($logs);
-    
+
     $emailResults[] = [
         'email' => $email,
         'status' => $status,
         'logs' => $logs,
         'analyzer' => $analyzer
     ];
-    
+
     $allLogs = array_merge($allLogs, $logs);
-    
+
     echo "Status: $status\n";
-    echo "Log entries: " . count($logs) . "\n";
-    echo "Success rate: " . number_format($analyzer->getSuccessRate(), 1) . "%\n";
-    echo "Has errors: " . ($analyzer->hasErrors() ? "Yes" : "No") . "\n\n";
+    echo "Log entries: ".count($logs)."\n";
+    echo "Success rate: ".number_format($analyzer->getSuccessRate(), 1)."%\n";
+    echo "Has errors: ".($analyzer->hasErrors() ? "Yes" : "No")."\n\n";
 }
 
 // Overall analysis
 echo "OVERALL ANALYSIS\n";
-echo str_repeat("=", 60) . "\n";
+echo str_repeat("=", 60)."\n";
 $overallAnalyzer = new SMTPLogAnalyzer($allLogs);
 
-echo "Total log entries: " . count($allLogs) . "\n";
-echo "Overall success rate: " . number_format($overallAnalyzer->getSuccessRate(), 1) . "%\n";
-echo "Total errors found: " . count($overallAnalyzer->getErrors()) . "\n\n";
+echo "Total log entries: ".count($allLogs)."\n";
+echo "Overall success rate: ".number_format($overallAnalyzer->getSuccessRate(), 1)."%\n";
+echo "Total errors found: ".count($overallAnalyzer->getErrors())."\n\n";
 
 // Phase analysis
 echo "SMTP PHASE ANALYSIS\n";
-echo str_repeat("=", 60) . "\n";
+echo str_repeat("=", 60)."\n";
 
 $connectionLogs = $overallAnalyzer->getConnectionPhase();
 $authLogs = $overallAnalyzer->getAuthenticationPhase();
 $mailLogs = $overallAnalyzer->getMailTransactionPhase();
 
-echo "Connection phase entries: " . count($connectionLogs) . "\n";
-echo "Authentication phase entries: " . count($authLogs) . "\n";
-echo "Mail transaction phase entries: " . count($mailLogs) . "\n\n";
+echo "Connection phase entries: ".count($connectionLogs)."\n";
+echo "Authentication phase entries: ".count($authLogs)."\n";
+echo "Mail transaction phase entries: ".count($mailLogs)."\n\n";
 
 // Error analysis
 if ($overallAnalyzer->hasErrors()) {
     echo "ERROR ANALYSIS\n";
-    echo str_repeat("=", 60) . "\n";
-    
+    echo str_repeat("=", 60)."\n";
+
     $errors = $overallAnalyzer->getErrors();
+
     foreach ($errors as $index => $error) {
-        echo "Error #" . ($index + 1) . ":\n";
-        echo "  Code: " . ($error['response-code'] ?? 'N/A') . "\n";
-        echo "  Message: " . ($error['response-message'] ?? 'N/A') . "\n";
-        echo "  Command: " . ($error['command'] ?? 'N/A') . "\n\n";
+        echo "Error #".($index + 1).":\n";
+        echo "  Code: ".($error['response-code'] ?? 'N/A')."\n";
+        echo "  Message: ".($error['response-message'] ?? 'N/A')."\n";
+        echo "  Command: ".($error['command'] ?? 'N/A')."\n\n";
     }
 }
 
 // Performance metrics
 echo "PERFORMANCE METRICS\n";
-echo str_repeat("=", 60) . "\n";
+echo str_repeat("=", 60)."\n";
 
 $avgLogsPerEmail = count($allLogs) / count($emails);
-echo "Average log entries per email: " . number_format($avgLogsPerEmail, 1) . "\n";
+echo "Average log entries per email: ".number_format($avgLogsPerEmail, 1)."\n";
 
 // Most common response codes
 $codeCounts = [];
+
 foreach ($allLogs as $log) {
     $code = $log['response-code'] ?? 'Unknown';
     $codeCounts[$code] = ($codeCounts[$code] ?? 0) + 1;
@@ -218,35 +228,36 @@ foreach ($allLogs as $log) {
 
 arsort($codeCounts);
 echo "\nMost common response codes:\n";
+
 foreach (array_slice($codeCounts, 0, 5) as $code => $count) {
     echo "  $code: $count occurrences\n";
 }
 
 // Generate detailed report
-$reportFile = __DIR__ . '/detailed-log-analysis.txt';
+$reportFile = __DIR__.'/detailed-log-analysis.txt';
 $report = "SMTP LOG ANALYSIS REPORT\n";
-$report .= "Generated: " . date('Y-m-d H:i:s') . "\n";
-$report .= str_repeat("=", 60) . "\n\n";
+$report .= "Generated: ".date('Y-m-d H:i:s')."\n";
+$report .= str_repeat("=", 60)."\n\n";
 
 $report .= "SUMMARY\n";
-$report .= "Total emails processed: " . count($emails) . "\n";
-$report .= "Total log entries: " . count($allLogs) . "\n";
-$report .= "Overall success rate: " . number_format($overallAnalyzer->getSuccessRate(), 1) . "%\n";
-$report .= "Errors found: " . count($overallAnalyzer->getErrors()) . "\n\n";
+$report .= "Total emails processed: ".count($emails)."\n";
+$report .= "Total log entries: ".count($allLogs)."\n";
+$report .= "Overall success rate: ".number_format($overallAnalyzer->getSuccessRate(), 1)."%\n";
+$report .= "Errors found: ".count($overallAnalyzer->getErrors())."\n\n";
 
 foreach ($emailResults as $index => $result) {
     $emailNum = $index + 1;
     $report .= "EMAIL #$emailNum DETAILS\n";
-    $report .= str_repeat("-", 30) . "\n";
-    $report .= "Subject: " . $result['email']->getSubject() . "\n";
-    $report .= "Status: " . $result['status'] . "\n";
-    $report .= "Log entries: " . count($result['logs']) . "\n";
-    $report .= "Success rate: " . number_format($result['analyzer']->getSuccessRate(), 1) . "%\n\n";
-    
+    $report .= str_repeat("-", 30)."\n";
+    $report .= "Subject: ".$result['email']->getSubject()."\n";
+    $report .= "Status: ".$result['status']."\n";
+    $report .= "Log entries: ".count($result['logs'])."\n";
+    $report .= "Success rate: ".number_format($result['analyzer']->getSuccessRate(), 1)."%\n\n";
+
     foreach ($result['logs'] as $logIndex => $log) {
-        $report .= "  Entry " . ($logIndex + 1) . ": ";
-        $report .= ($log['response-code'] ?? 'N/A') . " - ";
-        $report .= ($log['response-message'] ?? 'N/A') . "\n";
+        $report .= "  Entry ".($logIndex + 1).": ";
+        $report .= ($log['response-code'] ?? 'N/A')." - ";
+        $report .= ($log['response-message'] ?? 'N/A')."\n";
     }
     $report .= "\n";
 }
@@ -256,7 +267,7 @@ echo "\n📄 Detailed report saved to: $reportFile\n";
 
 // Recommendations based on analysis
 echo "\nRECOMMENDations\n";
-echo str_repeat("=", 60) . "\n";
+echo str_repeat("=", 60)."\n";
 
 if ($overallAnalyzer->getSuccessRate() < 80) {
     echo "⚠️  Low success rate detected. Check SMTP configuration.\n";

--- a/examples/accessing-log/smtp-logging.php
+++ b/examples/accessing-log/smtp-logging.php
@@ -2,9 +2,9 @@
 
 require '../../vendor/autoload.php';
 
+use WebFiori\Mail\AccountOption;
 use WebFiori\Mail\Email;
 use WebFiori\Mail\SMTPAccount;
-use WebFiori\Mail\AccountOption;
 
 // Configure SMTP account
 $smtpAccount = new SMTPAccount([
@@ -39,29 +39,29 @@ $logList->addChild('li')->text('Connection and authentication details');
 
 // Attempt to send email and capture logs
 echo "Attempting to send email...\n";
-echo str_repeat("=", 50) . "\n";
+echo str_repeat("=", 50)."\n";
 
 try {
     $email->send();
     echo "✅ Email sent successfully!\n\n";
 } catch (Exception $e) {
-    echo "❌ Email sending failed: " . $e->getMessage() . "\n\n";
+    echo "❌ Email sending failed: ".$e->getMessage()."\n\n";
 }
 
 // Access and display SMTP logs
 $logs = $email->getLog();
 
 echo "SMTP LOG ANALYSIS\n";
-echo str_repeat("=", 50) . "\n";
-echo "Total log entries: " . count($logs) . "\n\n";
+echo str_repeat("=", 50)."\n";
+echo "Total log entries: ".count($logs)."\n\n";
 
 if (!empty($logs)) {
     foreach ($logs as $index => $logEntry) {
-        echo "Entry #" . ($index + 1) . ":\n";
-        echo "  Command: " . ($logEntry['command'] ?? 'N/A') . "\n";
-        echo "  Response Code: " . ($logEntry['response-code'] ?? 'N/A') . "\n";
-        echo "  Response Message: " . ($logEntry['response-message'] ?? 'N/A') . "\n";
-        echo str_repeat("-", 30) . "\n";
+        echo "Entry #".($index + 1).":\n";
+        echo "  Command: ".($logEntry['command'] ?? 'N/A')."\n";
+        echo "  Response Code: ".($logEntry['response-code'] ?? 'N/A')."\n";
+        echo "  Response Message: ".($logEntry['response-message'] ?? 'N/A')."\n";
+        echo str_repeat("-", 30)."\n";
     }
 } else {
     echo "No SMTP logs available.\n";
@@ -73,7 +73,7 @@ if (!empty($logs)) {
 
 // Analyze logs for common patterns
 echo "\nLOG ANALYSIS\n";
-echo str_repeat("=", 50) . "\n";
+echo str_repeat("=", 50)."\n";
 
 $successCodes = ['220', '250', '354', '221'];
 $authCodes = ['334', '235'];
@@ -85,7 +85,7 @@ $errorCount = 0;
 
 foreach ($logs as $logEntry) {
     $code = $logEntry['response-code'] ?? '';
-    
+
     if (in_array($code, $successCodes)) {
         $successCount++;
     } elseif (in_array($code, $authCodes)) {
@@ -95,32 +95,32 @@ foreach ($logs as $logEntry) {
     }
 }
 
-echo "Success responses: " . $successCount . "\n";
-echo "Authentication responses: " . $authCount . "\n";
-echo "Error responses: " . $errorCount . "\n";
+echo "Success responses: ".$successCount."\n";
+echo "Authentication responses: ".$authCount."\n";
+echo "Error responses: ".$errorCount."\n";
 
 // Save logs to file for later analysis
-$logFile = __DIR__ . '/smtp-logs.txt';
-$logContent = "SMTP Log - " . date('Y-m-d H:i:s') . "\n";
-$logContent .= str_repeat("=", 50) . "\n";
-$logContent .= "Subject: " . $email->getSubject() . "\n";
-$logContent .= "Recipients: " . implode(', ', array_keys($email->getTo())) . "\n";
-$logContent .= "Total Entries: " . count($logs) . "\n\n";
+$logFile = __DIR__.'/smtp-logs.txt';
+$logContent = "SMTP Log - ".date('Y-m-d H:i:s')."\n";
+$logContent .= str_repeat("=", 50)."\n";
+$logContent .= "Subject: ".$email->getSubject()."\n";
+$logContent .= "Recipients: ".implode(', ', array_keys($email->getTo()))."\n";
+$logContent .= "Total Entries: ".count($logs)."\n\n";
 
 foreach ($logs as $index => $logEntry) {
-    $logContent .= "Entry #" . ($index + 1) . ":\n";
-    $logContent .= "  Command: " . ($logEntry['command'] ?? 'N/A') . "\n";
-    $logContent .= "  Code: " . ($logEntry['response-code'] ?? 'N/A') . "\n";
-    $logContent .= "  Message: " . ($logEntry['response-message'] ?? 'N/A') . "\n";
-    $logContent .= str_repeat("-", 30) . "\n";
+    $logContent .= "Entry #".($index + 1).":\n";
+    $logContent .= "  Command: ".($logEntry['command'] ?? 'N/A')."\n";
+    $logContent .= "  Code: ".($logEntry['response-code'] ?? 'N/A')."\n";
+    $logContent .= "  Message: ".($logEntry['response-message'] ?? 'N/A')."\n";
+    $logContent .= str_repeat("-", 30)."\n";
 }
 
 file_put_contents($logFile, $logContent);
-echo "\n📄 Logs saved to: " . $logFile . "\n";
+echo "\n📄 Logs saved to: ".$logFile."\n";
 
 // Display common SMTP response codes for reference
 echo "\nCOMMON SMTP RESPONSE CODES\n";
-echo str_repeat("=", 50) . "\n";
+echo str_repeat("=", 50)."\n";
 $responseCodes = [
     '220' => 'Service ready',
     '221' => 'Service closing transmission channel',
@@ -148,5 +148,5 @@ $responseCodes = [
 ];
 
 foreach ($responseCodes as $code => $description) {
-    echo $code . " - " . $description . "\n";
+    echo $code." - ".$description."\n";
 }

--- a/examples/attachments/create-sample-files.php
+++ b/examples/attachments/create-sample-files.php
@@ -2,7 +2,7 @@
 
 // Create sample files for attachment examples
 
-$sampleDir = __DIR__ . '/sample-files';
+$sampleDir = __DIR__.'/sample-files';
 
 // Create sample-files directory if it doesn't exist
 if (!is_dir($sampleDir)) {
@@ -61,7 +61,7 @@ startxref
 299
 %%EOF";
 
-file_put_contents($sampleDir . '/document.pdf', $pdfContent);
+file_put_contents($sampleDir.'/document.pdf', $pdfContent);
 echo "Created sample document.pdf\n";
 
 // Create sample text file
@@ -79,12 +79,12 @@ Features demonstrated:
 For more information, visit: https://github.com/WebFiori/mail
 ";
 
-file_put_contents($sampleDir . '/readme.txt', $textContent);
+file_put_contents($sampleDir.'/readme.txt', $textContent);
 echo "Created sample readme.txt\n";
 
 // Create a simple image file (1x1 pixel PNG)
 $imageData = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI9jU8j8wAAAABJRU5ErkJggg==');
-file_put_contents($sampleDir . '/image.jpg', $imageData);
+file_put_contents($sampleDir.'/image.jpg', $imageData);
 echo "Created sample image.jpg\n";
 
 // Create CSV file
@@ -94,7 +94,7 @@ Jane Smith,jane@example.com,Marketing
 Bob Johnson,bob@example.com,Sales
 Alice Brown,alice@example.com,HR";
 
-file_put_contents($sampleDir . '/contacts.csv', $csvContent);
+file_put_contents($sampleDir.'/contacts.csv', $csvContent);
 echo "Created sample contacts.csv\n";
 
 echo "\nAll sample files created successfully!\n";

--- a/examples/attachments/file-attachments.php
+++ b/examples/attachments/file-attachments.php
@@ -2,10 +2,10 @@
 
 require '../../vendor/autoload.php';
 
+use webfiori\file\File;
+use WebFiori\Mail\AccountOption;
 use WebFiori\Mail\Email;
 use WebFiori\Mail\SMTPAccount;
-use WebFiori\Mail\AccountOption;
-use webfiori\file\File;
 
 // Configure SMTP account
 $smtpAccount = new SMTPAccount([
@@ -31,7 +31,8 @@ $email->insert('h2')->text('File Attachments Demo');
 $email->insert('p')->text('This email demonstrates different ways to attach files using WebFiori Mailer.');
 
 // Method 1: Attach file using file path (string)
-$documentPath = __DIR__ . '/sample-files/document.pdf';
+$documentPath = __DIR__.'/sample-files/document.pdf';
+
 if (file_exists($documentPath)) {
     $email->addAttachment($documentPath);
     $email->insert('p')->text('✅ Attached: document.pdf (using file path)');
@@ -40,7 +41,8 @@ if (file_exists($documentPath)) {
 }
 
 // Method 2: Attach file using File object
-$imagePath = __DIR__ . '/sample-files/image.jpg';
+$imagePath = __DIR__.'/sample-files/image.jpg';
+
 if (file_exists($imagePath)) {
     $imageFile = new File($imagePath);
     $email->addAttachment($imageFile);
@@ -50,7 +52,8 @@ if (file_exists($imagePath)) {
 }
 
 // Method 3: Using fluent interface
-$textPath = __DIR__ . '/sample-files/readme.txt';
+$textPath = __DIR__.'/sample-files/readme.txt';
+
 if (file_exists($textPath)) {
     $email->attach($textPath);
     $email->insert('p')->text('✅ Attached: readme.txt (using fluent interface)');
@@ -62,12 +65,13 @@ if (file_exists($textPath)) {
 $attachments = $email->getAttachments();
 $email->insert('hr');
 $email->insert('h3')->text('Attachment Summary');
-$email->insert('p')->text('Total attachments: ' . count($attachments));
+$email->insert('p')->text('Total attachments: '.count($attachments));
 
 if (!empty($attachments)) {
     $list = $email->insert('ul');
+
     foreach ($attachments as $attachment) {
-        $list->addChild('li')->text($attachment->getName() . ' (' . $attachment->getSize() . ' bytes)');
+        $list->addChild('li')->text($attachment->getName().' ('.$attachment->getSize().' bytes)');
     }
 }
 
@@ -75,7 +79,7 @@ if (!empty($attachments)) {
 try {
     $email->send();
     echo "Email with attachments sent successfully!\n";
-    echo "Total attachments: " . count($attachments) . "\n";
+    echo "Total attachments: ".count($attachments)."\n";
 } catch (Exception $e) {
-    echo "Failed to send email: " . $e->getMessage() . "\n";
+    echo "Failed to send email: ".$e->getMessage()."\n";
 }

--- a/examples/basic-usage/basic-email.php
+++ b/examples/basic-usage/basic-email.php
@@ -2,9 +2,9 @@
 
 require '../../vendor/autoload.php';
 
+use WebFiori\Mail\AccountOption;
 use WebFiori\Mail\Email;
 use WebFiori\Mail\SMTPAccount;
-use WebFiori\Mail\AccountOption;
 
 // Configure SMTP account
 $smtpAccount = new SMTPAccount([
@@ -34,5 +34,5 @@ try {
     $email->send();
     echo "Email sent successfully!\n";
 } catch (Exception $e) {
-    echo "Failed to send email: " . $e->getMessage() . "\n";
+    echo "Failed to send email: ".$e->getMessage()."\n";
 }

--- a/examples/basic-usage/fluent-interface.php
+++ b/examples/basic-usage/fluent-interface.php
@@ -2,9 +2,9 @@
 
 require '../../vendor/autoload.php';
 
+use WebFiori\Mail\AccountOption;
 use WebFiori\Mail\Email;
 use WebFiori\Mail\SMTPAccount;
-use WebFiori\Mail\AccountOption;
 
 // Configure SMTP account
 $smtpAccount = new SMTPAccount([
@@ -20,20 +20,19 @@ $smtpAccount = new SMTPAccount([
 // Create and send email using fluent interface
 try {
     $email = new Email($smtpAccount);
-    
+
     $email->to('recipient@example.com', 'Recipient Name')
           ->cc('manager@example.com', 'Manager')
           ->subject('Fluent Interface Demo')
           ->priority(1);
-    
+
     // Add content
     $email->insert('h2')->text('Fluent Interface Example');
     $email->insert('p')->text('This email was created using method chaining for a cleaner, more readable syntax.');
-    
+
     // Send the email
     $email->send();
     echo "Email sent successfully using fluent interface!\n";
-    
 } catch (Exception $e) {
-    echo "Failed to send email: " . $e->getMessage() . "\n";
+    echo "Failed to send email: ".$e->getMessage()."\n";
 }

--- a/examples/callbacks/after-send-callbacks.php
+++ b/examples/callbacks/after-send-callbacks.php
@@ -2,9 +2,9 @@
 
 require '../../vendor/autoload.php';
 
+use WebFiori\Mail\AccountOption;
 use WebFiori\Mail\Email;
 use WebFiori\Mail\SMTPAccount;
-use WebFiori\Mail\AccountOption;
 
 // Configure SMTP account
 $smtpAccount = new SMTPAccount([
@@ -30,7 +30,8 @@ $email->insert('p')->text('This email demonstrates after-send callback functiona
 $email->insert('p')->text('Various actions will be performed after this email is sent.');
 
 // Callback 1: Log successful delivery
-$email->addAfterSend(function (Email $email) {
+$email->addAfterSend(function (Email $email)
+{
     $logEntry = [
         'timestamp' => date('c'),
         'status' => 'sent',
@@ -39,17 +40,18 @@ $email->addAfterSend(function (Email $email) {
         'smtp_server' => $email->getSMTPAccount()->getServerAddress(),
         'sender' => $email->getSMTPAccount()->getSenderAddress()
     ];
-    
-    $logFile = __DIR__ . '/delivery-log.json';
+
+    $logFile = __DIR__.'/delivery-log.json';
     $existingLogs = file_exists($logFile) ? json_decode(file_get_contents($logFile), true) : [];
     $existingLogs[] = $logEntry;
     file_put_contents($logFile, json_encode($existingLogs, JSON_PRETTY_PRINT));
-    
+
     echo "📝 Delivery logged successfully.\n";
 });
 
 // Callback 2: Update database or external system
-$email->addAfterSend(function (Email $email, array $config) {
+$email->addAfterSend(function (Email $email, array $config)
+{
     // Simulate database update
     $updateData = [
         'email_id' => uniqid('email_'),
@@ -58,18 +60,19 @@ $email->addAfterSend(function (Email $email, array $config) {
         'recipient_count' => count($email->getTo()),
         'status' => 'delivered'
     ];
-    
+
     // In real application, this would be a database insert/update
-    $dbFile = __DIR__ . '/email_database.json';
+    $dbFile = __DIR__.'/email_database.json';
     $records = file_exists($dbFile) ? json_decode(file_get_contents($dbFile), true) : [];
     $records[] = $updateData;
     file_put_contents($dbFile, json_encode($records, JSON_PRETTY_PRINT));
-    
+
     echo "💾 Database updated with delivery information.\n";
 }, ['db_config' => 'example']);
 
 // Callback 3: Send notification to administrators
-$email->addAfterSend(function (Email $email) {
+$email->addAfterSend(function (Email $email)
+{
     $notificationData = [
         'type' => 'email_sent',
         'timestamp' => date('c'),
@@ -79,18 +82,19 @@ $email->addAfterSend(function (Email $email) {
             'server' => $email->getSMTPAccount()->getServerAddress()
         ]
     ];
-    
+
     // Simulate admin notification (could be webhook, API call, etc.)
-    $notificationFile = __DIR__ . '/admin-notifications.json';
+    $notificationFile = __DIR__.'/admin-notifications.json';
     $notifications = file_exists($notificationFile) ? json_decode(file_get_contents($notificationFile), true) : [];
     $notifications[] = $notificationData;
     file_put_contents($notificationFile, json_encode($notifications, JSON_PRETTY_PRINT));
-    
+
     echo "🔔 Administrator notified of email delivery.\n";
 });
 
 // Callback 4: Analytics and metrics collection
-$email->addAfterSend(function (Email $email) {
+$email->addAfterSend(function (Email $email)
+{
     $metrics = [
         'timestamp' => time(),
         'date' => date('Y-m-d'),
@@ -103,41 +107,45 @@ $email->addAfterSend(function (Email $email) {
         'priority' => $email->getPriority(),
         'smtp_logs' => count($email->getLog())
     ];
-    
-    $metricsFile = __DIR__ . '/email-metrics.json';
+
+    $metricsFile = __DIR__.'/email-metrics.json';
     $allMetrics = file_exists($metricsFile) ? json_decode(file_get_contents($metricsFile), true) : [];
     $allMetrics[] = $metrics;
     file_put_contents($metricsFile, json_encode($allMetrics, JSON_PRETTY_PRINT));
-    
+
     echo "📊 Metrics collected for analytics.\n";
 });
 
 // Callback 5: Cleanup and maintenance tasks
-$email->addAfterSend(function (Email $email) {
+$email->addAfterSend(function (Email $email)
+{
     // Cleanup temporary files (if any)
-    $tempDir = __DIR__ . '/temp';
+    $tempDir = __DIR__.'/temp';
+
     if (is_dir($tempDir)) {
-        $files = glob($tempDir . '/*');
+        $files = glob($tempDir.'/*');
         $cleanedCount = 0;
+
         foreach ($files as $file) {
             if (is_file($file) && filemtime($file) < (time() - 3600)) { // 1 hour old
                 unlink($file);
                 $cleanedCount++;
             }
         }
+
         if ($cleanedCount > 0) {
             echo "🧹 Cleaned up $cleanedCount temporary files.\n";
         }
     }
-    
+
     // Log cleanup activity
     $cleanupLog = [
         'timestamp' => date('c'),
         'action' => 'post_send_cleanup',
         'files_cleaned' => $cleanedCount ?? 0
     ];
-    
-    $cleanupFile = __DIR__ . '/cleanup-log.json';
+
+    $cleanupFile = __DIR__.'/cleanup-log.json';
     $cleanupLogs = file_exists($cleanupFile) ? json_decode(file_get_contents($cleanupFile), true) : [];
     $cleanupLogs[] = $cleanupLog;
     file_put_contents($cleanupFile, json_encode($cleanupLogs, JSON_PRETTY_PRINT));
@@ -145,31 +153,30 @@ $email->addAfterSend(function (Email $email) {
 
 // Display information before sending
 echo "AFTER SEND CALLBACKS DEMO\n";
-echo str_repeat("=", 50) . "\n";
-echo "Email Subject: " . $email->getSubject() . "\n";
-echo "Recipients: " . implode(', ', array_keys($email->getTo())) . "\n";
+echo str_repeat("=", 50)."\n";
+echo "Email Subject: ".$email->getSubject()."\n";
+echo "Recipients: ".implode(', ', array_keys($email->getTo()))."\n";
 echo "After-send callbacks registered: 5\n\n";
 
 echo "Sending email...\n";
-echo str_repeat("-", 30) . "\n";
+echo str_repeat("-", 30)."\n";
 
 // Send the email
 try {
     $email->send();
     echo "✅ Email sent successfully!\n\n";
-    
+
     echo "After-send callbacks executed:\n";
-    echo str_repeat("-", 30) . "\n";
+    echo str_repeat("-", 30)."\n";
     // Callbacks execute automatically after successful send
-    
 } catch (Exception $e) {
-    echo "❌ Failed to send email: " . $e->getMessage() . "\n";
+    echo "❌ Failed to send email: ".$e->getMessage()."\n";
     echo "After-send callbacks will NOT execute on failure.\n";
 }
 
 // Display generated files
 echo "\nGENERATED FILES\n";
-echo str_repeat("=", 50) . "\n";
+echo str_repeat("=", 50)."\n";
 
 $generatedFiles = [
     'delivery-log.json' => 'Email delivery log',
@@ -180,7 +187,8 @@ $generatedFiles = [
 ];
 
 foreach ($generatedFiles as $filename => $description) {
-    $filepath = __DIR__ . '/' . $filename;
+    $filepath = __DIR__.'/'.$filename;
+
     if (file_exists($filepath)) {
         echo "📄 $filename - $description\n";
     }
@@ -188,7 +196,7 @@ foreach ($generatedFiles as $filename => $description) {
 
 // Example of error handling with callbacks
 echo "\nERROR HANDLING EXAMPLE\n";
-echo str_repeat("=", 50) . "\n";
+echo str_repeat("=", 50)."\n";
 
 // Create an email that will likely fail (invalid SMTP config)
 $failingAccount = new SMTPAccount([
@@ -207,7 +215,8 @@ $failingEmail->subject('This will fail')
              ->insert('p')->text('This email is designed to fail.');
 
 // Add after-send callback (won't execute on failure)
-$failingEmail->addAfterSend(function (Email $email) {
+$failingEmail->addAfterSend(function (Email $email)
+{
     echo "This callback should NOT execute because sending will fail.\n";
 });
 
@@ -217,13 +226,13 @@ try {
     $failingEmail->send();
     echo "Unexpected success!\n";
 } catch (Exception $e) {
-    echo "Expected failure: " . $e->getMessage() . "\n";
+    echo "Expected failure: ".$e->getMessage()."\n";
     echo "After-send callbacks correctly did NOT execute.\n";
 }
 
 // Show callback execution summary
 echo "\nCALLBACK EXECUTION SUMMARY\n";
-echo str_repeat("=", 50) . "\n";
+echo str_repeat("=", 50)."\n";
 echo "✅ Successful email: All 5 after-send callbacks executed\n";
 echo "❌ Failed email: 0 after-send callbacks executed (correct behavior)\n";
 echo "\nAfter-send callbacks only execute when email sending succeeds.\n";

--- a/examples/callbacks/before-send-callbacks.php
+++ b/examples/callbacks/before-send-callbacks.php
@@ -2,9 +2,9 @@
 
 require '../../vendor/autoload.php';
 
+use WebFiori\Mail\AccountOption;
 use WebFiori\Mail\Email;
 use WebFiori\Mail\SMTPAccount;
-use WebFiori\Mail\AccountOption;
 
 // Configure SMTP account
 $smtpAccount = new SMTPAccount([
@@ -29,9 +29,10 @@ $email->insert('h1')->text('Before Send Callbacks');
 $email->insert('p')->text('This email demonstrates various before-send callback functionalities.');
 
 // Callback 1: Add dynamic content based on current time
-$email->addBeforeSend(function (Email $email) {
+$email->addBeforeSend(function (Email $email)
+{
     $currentHour = (int)date('H');
-    
+
     if ($currentHour < 12) {
         $greeting = 'Good Morning!';
         $timeClass = 'morning';
@@ -42,7 +43,7 @@ $email->addBeforeSend(function (Email $email) {
         $greeting = 'Good Evening!';
         $timeClass = 'evening';
     }
-    
+
     $greetingDiv = $email->insert('div', [
         'class' => $timeClass,
         'style' => [
@@ -53,7 +54,7 @@ $email->addBeforeSend(function (Email $email) {
         ]
     ]);
     $greetingDiv->addChild('h3')->text($greeting);
-    $greetingDiv->addChild('p')->text('This greeting was added dynamically based on the current time: ' . date('H:i:s'));
+    $greetingDiv->addChild('p')->text('This greeting was added dynamically based on the current time: '.date('H:i:s'));
 });
 
 // Callback 2: Add user-specific personalization
@@ -63,7 +64,8 @@ $userData = [
     'account_type' => 'Premium'
 ];
 
-$email->addBeforeSend(function (Email $email, array $userData) {
+$email->addBeforeSend(function (Email $email, array $userData)
+{
     $personalDiv = $email->insert('div', [
         'style' => [
             'background' => '#f0f8e8',
@@ -72,16 +74,16 @@ $email->addBeforeSend(function (Email $email, array $userData) {
             'margin' => '15px 0'
         ]
     ]);
-    
+
     $personalDiv->addChild('h3')->text('Personal Information');
-    $personalDiv->addChild('p')->text('Hello ' . $userData['name'] . '!');
-    $personalDiv->addChild('p')->text('Account Type: ' . $userData['account_type']);
-    $personalDiv->addChild('p')->text('Last Login: ' . $userData['last_login']);
-    
+    $personalDiv->addChild('p')->text('Hello '.$userData['name'].'!');
+    $personalDiv->addChild('p')->text('Account Type: '.$userData['account_type']);
+    $personalDiv->addChild('p')->text('Last Login: '.$userData['last_login']);
 }, [$userData]);
 
 // Callback 3: Add system information and metadata
-$email->addBeforeSend(function (Email $email) {
+$email->addBeforeSend(function (Email $email)
+{
     $systemInfo = $email->insert('div', [
         'style' => [
             'background' => '#fff3cd',
@@ -92,26 +94,27 @@ $email->addBeforeSend(function (Email $email) {
             'font-size' => '12px'
         ]
     ]);
-    
+
     $systemInfo->addChild('h4')->text('System Information');
     $infoList = $systemInfo->addChild('ul');
-    $infoList->addChild('li')->text('Server: ' . ($_SERVER['SERVER_NAME'] ?? 'localhost'));
-    $infoList->addChild('li')->text('PHP Version: ' . PHP_VERSION);
-    $infoList->addChild('li')->text('Timestamp: ' . date('Y-m-d H:i:s T'));
-    $infoList->addChild('li')->text('Email ID: ' . uniqid('email_'));
+    $infoList->addChild('li')->text('Server: '.($_SERVER['SERVER_NAME'] ?? 'localhost'));
+    $infoList->addChild('li')->text('PHP Version: '.PHP_VERSION);
+    $infoList->addChild('li')->text('Timestamp: '.date('Y-m-d H:i:s T'));
+    $infoList->addChild('li')->text('Email ID: '.uniqid('email_'));
 });
 
 // Callback 4: Validate and modify email before sending
-$email->addBeforeSend(function (Email $email) {
+$email->addBeforeSend(function (Email $email)
+{
     // Add validation
     if (empty($email->getTo())) {
         throw new Exception('No recipients specified');
     }
-    
+
     if (strlen($email->getSubject()) < 5) {
         throw new Exception('Subject too short');
     }
-    
+
     // Add footer automatically
     $email->insert('hr');
     $footer = $email->insert('div', [
@@ -124,15 +127,16 @@ $email->addBeforeSend(function (Email $email) {
             'border-top' => '1px solid #eee'
         ]
     ]);
-    
+
     $footer->addChild('p')->text('This email was sent automatically by WebFiori Mailer.');
     $footer->addChild('p')->text('© 2024 Your Company Name. All rights reserved.');
-    
+
     echo "✅ Email validation passed and footer added.\n";
 });
 
 // Callback 5: Logging and analytics
-$email->addBeforeSend(function (Email $email) {
+$email->addBeforeSend(function (Email $email)
+{
     $logEntry = [
         'timestamp' => date('c'),
         'subject' => $email->getSubject(),
@@ -142,37 +146,37 @@ $email->addBeforeSend(function (Email $email) {
         'priority' => $email->getPriority(),
         'attachments' => count($email->getAttachments())
     ];
-    
+
     // Log to file
-    $logFile = __DIR__ . '/email-send-log.json';
+    $logFile = __DIR__.'/email-send-log.json';
     $existingLogs = file_exists($logFile) ? json_decode(file_get_contents($logFile), true) : [];
     $existingLogs[] = $logEntry;
     file_put_contents($logFile, json_encode($existingLogs, JSON_PRETTY_PRINT));
-    
+
     echo "📊 Email logged for analytics.\n";
 });
 
 // Display callback information
 echo "BEFORE SEND CALLBACKS DEMO\n";
-echo str_repeat("=", 50) . "\n";
-echo "Email Subject: " . $email->getSubject() . "\n";
-echo "Recipients: " . implode(', ', array_keys($email->getTo())) . "\n";
+echo str_repeat("=", 50)."\n";
+echo "Email Subject: ".$email->getSubject()."\n";
+echo "Recipients: ".implode(', ', array_keys($email->getTo()))."\n";
 echo "Callbacks registered: 5\n\n";
 
 echo "Executing callbacks and sending email...\n";
-echo str_repeat("-", 30) . "\n";
+echo str_repeat("-", 30)."\n";
 
 // Send the email (callbacks will execute automatically)
 try {
     $email->send();
     echo "✅ Email sent successfully with all callbacks executed!\n";
 } catch (Exception $e) {
-    echo "❌ Failed to send email: " . $e->getMessage() . "\n";
+    echo "❌ Failed to send email: ".$e->getMessage()."\n";
 }
 
 // Display what callbacks accomplished
 echo "\nCALLBACK RESULTS\n";
-echo str_repeat("=", 50) . "\n";
+echo str_repeat("=", 50)."\n";
 echo "1. ⏰ Time-based greeting added\n";
 echo "2. 👤 User personalization applied\n";
 echo "3. 🖥️  System information included\n";
@@ -180,14 +184,15 @@ echo "4. ✅ Email validation and footer added\n";
 echo "5. 📊 Analytics data logged\n";
 
 // Show log file location
-$logFile = __DIR__ . '/email-send-log.json';
+$logFile = __DIR__.'/email-send-log.json';
+
 if (file_exists($logFile)) {
-    echo "\n📄 Send log saved to: " . $logFile . "\n";
+    echo "\n📄 Send log saved to: ".$logFile."\n";
 }
 
 // Example of conditional callbacks
 echo "\nCONDITIONAL CALLBACK EXAMPLE\n";
-echo str_repeat("=", 50) . "\n";
+echo str_repeat("=", 50)."\n";
 
 $conditionalEmail = new Email($smtpAccount);
 $conditionalEmail->subject('Conditional Callback Test')
@@ -200,18 +205,20 @@ $conditionalEmail->insert('p')->text('This demonstrates conditional callback exe
 $environment = getenv('APP_ENV') ?: 'development';
 
 if ($environment === 'production') {
-    $conditionalEmail->addBeforeSend(function (Email $email) {
+    $conditionalEmail->addBeforeSend(function (Email $email)
+    {
         // Production-specific callback
         $email->insert('div', ['style' => ['color' => 'green']])
               ->addChild('p')->text('✅ Production environment - all systems operational.');
     });
 } else {
-    $conditionalEmail->addBeforeSend(function (Email $email) {
+    $conditionalEmail->addBeforeSend(function (Email $email)
+    {
         // Development-specific callback
         $email->insert('div', ['style' => ['color' => 'orange']])
               ->addChild('p')->text('⚠️ Development environment - for testing only.');
     });
 }
 
-echo "Environment: " . $environment . "\n";
+echo "Environment: ".$environment."\n";
 echo "Conditional callback will be applied based on environment.\n";

--- a/examples/oauth-usage/gmail-oauth.php
+++ b/examples/oauth-usage/gmail-oauth.php
@@ -2,9 +2,9 @@
 
 require '../../vendor/autoload.php';
 
+use WebFiori\Mail\AccountOption;
 use WebFiori\Mail\Email;
 use WebFiori\Mail\SMTPAccount;
-use WebFiori\Mail\AccountOption;
 
 // Configure Gmail OAuth account
 $gmailAccount = new SMTPAccount([
@@ -40,5 +40,5 @@ try {
     $email->send();
     echo "Email sent successfully using OAuth2!\n";
 } catch (Exception $e) {
-    echo "Failed to send email: " . $e->getMessage() . "\n";
+    echo "Failed to send email: ".$e->getMessage()."\n";
 }

--- a/examples/oauth-usage/microsoft-oauth.php
+++ b/examples/oauth-usage/microsoft-oauth.php
@@ -2,9 +2,9 @@
 
 require '../../vendor/autoload.php';
 
+use WebFiori\Mail\AccountOption;
 use WebFiori\Mail\Email;
 use WebFiori\Mail\SMTPAccount;
-use WebFiori\Mail\AccountOption;
 
 // Configure Microsoft OAuth account
 $microsoftAccount = new SMTPAccount([
@@ -48,5 +48,5 @@ try {
     $email->send();
     echo "Email sent successfully using Microsoft OAuth!\n";
 } catch (Exception $e) {
-    echo "Failed to send email: " . $e->getMessage() . "\n";
+    echo "Failed to send email: ".$e->getMessage()."\n";
 }

--- a/examples/sending-modes/production-mode.php
+++ b/examples/sending-modes/production-mode.php
@@ -2,10 +2,10 @@
 
 require '../../vendor/autoload.php';
 
-use WebFiori\Mail\Email;
-use WebFiori\Mail\SMTPAccount;
 use WebFiori\Mail\AccountOption;
+use WebFiori\Mail\Email;
 use WebFiori\Mail\SendMode;
+use WebFiori\Mail\SMTPAccount;
 
 // Configure SMTP account
 $smtpAccount = new SMTPAccount([
@@ -36,24 +36,23 @@ $email->insert('p')->text('This email demonstrates production mode usage with en
 
 $envInfo = $email->insert('div', ['style' => ['background' => '#e8f5e8', 'padding' => '15px', 'border-radius' => '5px']]);
 $envInfo->addChild('h3')->text('Environment Information:');
-$envInfo->addChild('p')->text('Current Environment: ' . strtoupper($environment));
-$envInfo->addChild('p')->text('Production Mode: ' . ($isProduction ? 'ENABLED' : 'DISABLED'));
+$envInfo->addChild('p')->text('Current Environment: '.strtoupper($environment));
+$envInfo->addChild('p')->text('Production Mode: '.($isProduction ? 'ENABLED' : 'DISABLED'));
 
 // Configure sending mode based on environment
 if ($isProduction) {
     // Production: Send to actual recipients
     $email->setMode(SendMode::LIVE);
-    
+
     $prodInfo = $email->insert('div', ['style' => ['background' => '#d4edda', 'padding' => '10px', 'border-left' => '4px solid #28a745']]);
     $prodInfo->addChild('h4')->text('✅ Production Mode Active');
     $prodInfo->addChild('p')->text('Emails will be sent to actual recipients.');
-    
 } else {
     // Development/Testing: Use test mode
     $email->setMode(SendMode::TEST_STORE, [
-        'store-path' => __DIR__ . '/email-previews'
+        'store-path' => __DIR__.'/email-previews'
     ]);
-    
+
     $testInfo = $email->insert('div', ['style' => ['background' => '#fff3cd', 'padding' => '10px', 'border-left' => '4px solid #ffc107']]);
     $testInfo->addChild('h4')->text('⚠️ Test Mode Active');
     $testInfo->addChild('p')->text('Emails will be stored as HTML files for preview.');
@@ -71,7 +70,8 @@ $practices->addChild('li')->text('Implement rate limiting for bulk emails');
 
 // Create preview directory if in test mode
 if (!$isProduction) {
-    $previewDir = __DIR__ . '/email-previews';
+    $previewDir = __DIR__.'/email-previews';
+
     if (!is_dir($previewDir)) {
         mkdir($previewDir, 0755, true);
     }
@@ -80,7 +80,7 @@ if (!$isProduction) {
 // Send the email
 try {
     $email->send();
-    
+
     if ($isProduction) {
         echo "✅ Email sent successfully in PRODUCTION mode!\n";
         echo "Recipient: customer@example.com\n";
@@ -88,29 +88,28 @@ try {
         echo "📧 Email stored successfully in TEST mode!\n";
         echo "Check email-previews directory for HTML preview.\n";
     }
-    
 } catch (Exception $e) {
-    echo "❌ Failed to send email: " . $e->getMessage() . "\n";
-    
+    echo "❌ Failed to send email: ".$e->getMessage()."\n";
+
     // In production, you might want to log this error
     if ($isProduction) {
-        error_log("Email sending failed: " . $e->getMessage());
+        error_log("Email sending failed: ".$e->getMessage());
     }
 }
 
 // Display configuration summary
-echo "\n" . str_repeat("=", 50) . "\n";
+echo "\n".str_repeat("=", 50)."\n";
 echo "CONFIGURATION SUMMARY\n";
-echo str_repeat("=", 50) . "\n";
-echo "Environment: " . $environment . "\n";
-echo "Mode: " . ($isProduction ? "LIVE (Production)" : "TEST (Development)") . "\n";
-echo "SMTP Server: " . $smtpAccount->getServerAddress() . "\n";
-echo "Sender: " . $smtpAccount->getSenderAddress() . "\n";
+echo str_repeat("=", 50)."\n";
+echo "Environment: ".$environment."\n";
+echo "Mode: ".($isProduction ? "LIVE (Production)" : "TEST (Development)")."\n";
+echo "SMTP Server: ".$smtpAccount->getServerAddress()."\n";
+echo "Sender: ".$smtpAccount->getSenderAddress()."\n";
 
 // Show how to set environment for production
 if (!$isProduction) {
-    echo "\n" . str_repeat("-", 30) . "\n";
+    echo "\n".str_repeat("-", 30)."\n";
     echo "To enable production mode, set:\n";
     echo "export APP_ENV=production\n";
-    echo str_repeat("-", 30) . "\n";
+    echo str_repeat("-", 30)."\n";
 }

--- a/examples/sending-modes/test-mode.php
+++ b/examples/sending-modes/test-mode.php
@@ -2,10 +2,10 @@
 
 require '../../vendor/autoload.php';
 
-use WebFiori\Mail\Email;
-use WebFiori\Mail\SMTPAccount;
 use WebFiori\Mail\AccountOption;
+use WebFiori\Mail\Email;
 use WebFiori\Mail\SendMode;
+use WebFiori\Mail\SMTPAccount;
 
 // Configure SMTP account
 $smtpAccount = new SMTPAccount([
@@ -40,7 +40,8 @@ $list->addChild('li')->text('Debug email content safely');
 $list->addChild('li')->text('No risk of sending test emails to real users');
 
 // Set test mode to store emails as HTML files
-$storageDir = __DIR__ . '/email-previews';
+$storageDir = __DIR__.'/email-previews';
+
 if (!is_dir($storageDir)) {
     mkdir($storageDir, 0755, true);
 }
@@ -54,9 +55,9 @@ try {
     $email->send();
     echo "Email stored successfully in test mode!\n";
     echo "Check the email-previews directory for the HTML file.\n";
-    echo "Storage directory: " . $storageDir . "\n";
+    echo "Storage directory: ".$storageDir."\n";
 } catch (Exception $e) {
-    echo "Failed to store email: " . $e->getMessage() . "\n";
+    echo "Failed to store email: ".$e->getMessage()."\n";
 }
 
 // Display mode information

--- a/examples/sending-modes/test-send-mode.php
+++ b/examples/sending-modes/test-send-mode.php
@@ -2,10 +2,10 @@
 
 require '../../vendor/autoload.php';
 
-use WebFiori\Mail\Email;
-use WebFiori\Mail\SMTPAccount;
 use WebFiori\Mail\AccountOption;
+use WebFiori\Mail\Email;
 use WebFiori\Mail\SendMode;
+use WebFiori\Mail\SMTPAccount;
 
 // Configure SMTP account
 $smtpAccount = new SMTPAccount([
@@ -60,14 +60,13 @@ try {
     $email->send();
     echo "Email sent successfully in test mode!\n";
     echo "Sent to test addresses instead of production recipients.\n";
-    
+
     // Show where the email actually went
     echo "\nTest addresses used:\n";
     echo "- developer@yourcompany.com\n";
     echo "- qa-team@yourcompany.com\n";
-    
 } catch (Exception $e) {
-    echo "Failed to send email: " . $e->getMessage() . "\n";
+    echo "Failed to send email: ".$e->getMessage()."\n";
 }
 
 // Display current mode

--- a/examples/transports/README.md
+++ b/examples/transports/README.md
@@ -1,0 +1,51 @@
+# Custom Transports
+
+WebFiori Mailer supports pluggable transports via `TransportInterface`. This allows you to swap the delivery mechanism without changing your email composition code.
+
+## SmtpTransport (Default)
+
+The built-in `SmtpTransport` handles SMTP delivery. You can use it explicitly to reuse a single connection across multiple emails:
+
+```php
+$transport = new SmtpTransport($account);
+
+foreach ($recipients as $recipient) {
+    $email = new Email($account);
+    $email->setSubject('Newsletter');
+    $email->addTo($recipient);
+    $email->insert('p')->text('Hello!');
+    $email->send($transport);
+
+    // Reset connection for next message
+    $transport->getServer()->reset();
+}
+```
+
+See [smtp-transport.php](smtp-transport.php) for the full example.
+
+## Custom Transports
+
+Implement `TransportInterface` to create your own transport:
+
+```php
+class NullTransport implements TransportInterface {
+    public array $sent = [];
+
+    public function send(Email $message): void {
+        $this->sent[] = $message;
+    }
+
+    public function getName(): string {
+        return 'null';
+    }
+}
+
+$email->send(new NullTransport());
+```
+
+This is useful for:
+- **Unit testing** — Capture emails without sending
+- **API providers** — Implement SES, SendGrid, etc.
+- **Logging** — Record all outgoing emails
+
+See [null-transport.php](null-transport.php) for the full example.

--- a/examples/transports/null-transport.php
+++ b/examples/transports/null-transport.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Example: Custom transport for testing.
+ *
+ * This demonstrates creating a null transport that captures sent emails
+ * without actually delivering them — useful for unit/integration testing.
+ */
+require '../../vendor/autoload.php';
+
+use WebFiori\Mail\AccountOption;
+use WebFiori\Mail\Email;
+use WebFiori\Mail\SMTPAccount;
+use WebFiori\Mail\TransportInterface;
+
+/**
+ * A transport that stores emails in memory instead of sending them.
+ */
+class NullTransport implements TransportInterface {
+    public array $sent = [];
+
+    public function send(Email $message): void {
+        $this->sent[] = $message;
+    }
+
+    public function getName(): string {
+        return 'null';
+    }
+}
+
+// Usage in tests
+$account = new SMTPAccount([
+    AccountOption::SERVER_ADDRESS => 'smtp.example.com',
+    AccountOption::PORT => 465,
+    AccountOption::USERNAME => 'test@example.com',
+    AccountOption::PASSWORD => 'password',
+    AccountOption::SENDER_ADDRESS => 'test@example.com',
+    AccountOption::SENDER_NAME => 'Test',
+    AccountOption::NAME => 'test'
+]);
+
+$transport = new NullTransport();
+
+$email = new Email($account);
+$email->setSubject('Welcome!');
+$email->addTo('user@example.com');
+$email->insert('p')->text('Thank you for signing up.');
+$email->send($transport);
+
+// Verify the email was "sent"
+echo "Emails captured: " . count($transport->sent) . "\n";
+echo "Subject: " . $transport->sent[0]->getSubject() . "\n";
+echo "Recipient: " . implode(', ', array_keys($transport->sent[0]->getTo())) . "\n";

--- a/examples/transports/smtp-transport.php
+++ b/examples/transports/smtp-transport.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Example: Using SmtpTransport for connection reuse.
+ *
+ * This demonstrates sending multiple emails over a single SMTP connection,
+ * which is more efficient than reconnecting for each message.
+ */
+require '../../vendor/autoload.php';
+
+use WebFiori\Mail\AccountOption;
+use WebFiori\Mail\Email;
+use WebFiori\Mail\SMTPAccount;
+use WebFiori\Mail\SmtpTransport;
+
+$account = new SMTPAccount([
+    AccountOption::SERVER_ADDRESS => 'smtp.gmail.com',
+    AccountOption::PORT => 587,
+    AccountOption::USERNAME => 'your-email@gmail.com',
+    AccountOption::PASSWORD => 'your-app-password',
+    AccountOption::SENDER_ADDRESS => 'your-email@gmail.com',
+    AccountOption::SENDER_NAME => 'Your Name',
+    AccountOption::NAME => 'gmail-account'
+]);
+
+// Create transport once — reuse for multiple emails
+$transport = new SmtpTransport($account);
+
+$recipients = [
+    'alice@example.com',
+    'bob@example.com',
+    'carol@example.com',
+];
+
+foreach ($recipients as $recipient) {
+    $email = new Email($account);
+    $email->setSubject('Monthly Newsletter');
+    $email->addTo($recipient);
+    $email->insert('p')->text("Hello $recipient, here is your newsletter.");
+
+    try {
+        $email->send($transport);
+        echo "Sent to $recipient\n";
+
+        // Reset the connection for the next message
+        $transport->getServer()->reset();
+    } catch (Exception $e) {
+        echo "Failed for $recipient: " . $e->getMessage() . "\n";
+    }
+}

--- a/tests/WebFiori/Tests/Mail/EmailMessageTest.php
+++ b/tests/WebFiori/Tests/Mail/EmailMessageTest.php
@@ -725,4 +725,47 @@ class EmailMessageTest extends TestCase {
         $commands = array_column($log, 'command');
         $this->assertTrue(in_array('RSET', $commands), 'RSET should have been sent for greylisting retry');
     }
+
+    /**
+     * @test
+     * Tests sending via SmtpTransport directly.
+     */
+    public function testSendViaSmtpTransport() {
+        $account = new SMTPAccount($this->getValidAccount());
+        $transport = new \WebFiori\Mail\SmtpTransport($account);
+
+        $message = new Email($account);
+        $message->setSubject('Transport Test');
+        $message->addTo('recipient@example.com');
+        $message->insert('p')->text('Sent via SmtpTransport.');
+        $message->send($transport);
+
+        $this->assertTrue($message->isSent());
+        $lastLog = $transport->getServer()->getLastLogEntry();
+        $this->assertEquals('QUIT', $lastLog['command']);
+        $this->assertEquals(221, $lastLog['code']);
+    }
+
+    /**
+     * @test
+     * Tests sending via a custom TransportInterface implementation.
+     */
+    public function testSendViaCustomTransport() {
+        $nullTransport = new class implements \WebFiori\Mail\TransportInterface {
+            public array $sent = [];
+            public function send(\WebFiori\Mail\Email $message): void { $this->sent[] = $message; }
+            public function getName(): string { return 'null'; }
+        };
+
+        $account = new SMTPAccount($this->getValidAccount());
+        $message = new Email($account);
+        $message->setSubject('Null Transport Test');
+        $message->addTo('recipient@example.com');
+        $message->insert('p')->text('Not actually sent.');
+        $message->send($nullTransport);
+
+        $this->assertTrue($message->isSent());
+        $this->assertCount(1, $nullTransport->sent);
+        $this->assertSame($message, $nullTransport->sent[0]);
+    }
 }


### PR DESCRIPTION
# Summary
Introduce a transport abstraction layer that decouples email composition from delivery.

## Motivation
The SMTP logic was embedded directly in `Email::send()`, coupling message composition to the delivery mechanism. This made it impossible to swap transports (API providers, null/mock for testing) or test without an SMTP server.

Fixes #57, Fixes #58

## Changes
- Added `TransportInterface` with `send(Email)` and `getName()` methods
- Added `SmtpTransport` class implementing `TransportInterface` with all SMTP delivery logic
- Updated `Email::send()` to accept `TransportInterface|SMTPServer|null` (fully backward compatible)
- Added `Email::getBoundary()` public method (needed by external transports)
- Default behavior unchanged: `$email->send()` still uses SMTP via the configured account

## How to Test / Verify
- 45 unit tests pass (43 existing + 2 new)
- `testSendViaSmtpTransport` — verifies SmtpTransport delivers correctly
- `testSendViaCustomTransport` — verifies a null/mock transport receives the message
- All existing tests confirm backward compatibility

## Breaking Changes and Migration Steps
None. Existing `$email->send()` calls work without modification.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [ ] I updated docs (if needed) [Docs Repo](https://github.com/WebFiori/docs)
- [x] I ran lint/cs-fixer (if applicable) (`composer fix-cs`)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #57, Closes #58